### PR TITLE
WIP - Support phan 2.4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"irc": "irc://freenode.net/wikimedia-dev"
 	},
 	"require": {
-		"phan/phan": "2.2.5",
+		"phan/phan": "2.4.5",
 		"php": "^7.2.0",
 		"ext-json": "*"
 	},

--- a/src/PreTaintednessVisitor.php
+++ b/src/PreTaintednessVisitor.php
@@ -4,6 +4,7 @@ use ast\Node;
 use Phan\CodeBase;
 use Phan\Language\Context;
 use Phan\Language\Element\PassByReferenceVariable;
+use Phan\Language\Element\Variable;
 use Phan\PluginV2\PluginAwarePreAnalysisVisitor;
 
 /**
@@ -144,7 +145,9 @@ class PreTaintednessVisitor extends PluginAwarePreAnalysisVisitor {
 
 			// Initially, the variable starts off with no taint.
 			$this->setTaintedness( $varObj, SecurityCheckPlugin::NO_TAINT );
-			$this->linkParamAndFunc( $varObj, $method, $i );
+			if ($varObj instanceof Variable) {  // TODO: Should linkParamAndFunc handle Phan\Language\Element\Property?
+				$this->linkParamAndFunc( $varObj, $method, $i );
+			}
 		}
 	}
 }

--- a/src/TaintednessBaseVisitor.php
+++ b/src/TaintednessBaseVisitor.php
@@ -738,6 +738,8 @@ trait TaintednessBaseVisitor {
 			case 'void':
 			case 'class-string':
 			case 'callable-string':
+			case 'callable-object':
+			case 'callable-array':
 				$taint = $this->mergeAddTaint( $taint, SecurityCheckPlugin::NO_TAINT );
 				break;
 			case 'string':
@@ -753,7 +755,7 @@ trait TaintednessBaseVisitor {
 			default:
 				// This means specific class.
 				// TODO - maybe look up __toString() method.
-				$fqsen = $type->asFQSEN();
+				$fqsen = $type->isObjectWithKnownFQSEN() ? $type->asFQSEN() : $type->__toString();
 				if ( !( $fqsen instanceof FullyQualifiedClassName ) ) {
 					$this->debug( __METHOD__, " $type not a class?" );
 					$taint = $this->mergeAddTaint( $taint, SecurityCheckPlugin::UNKNOWN_TAINT );


### PR DESCRIPTION
cc @Daimona - Some of these changes may apply to 2.2.5 as well. It'll probably take me a while to get set up to submit a PR for gerrit.

Also, the polyfill's memory usage is much lower in Phan 2.4.5 due to properly freeing cycles

One test fails.